### PR TITLE
Allow lookup hostIPs by DNS

### DIFF
--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile deps.external.httpCore
     compile deps.external.statsdClient
     compile deps.external.dns
+    testCompile 'org.mockito:mockito-all:1.9.5'
 }
 
 task distJar(type: OneJar) {

--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile deps.external.uuidGen
     compile deps.external.httpCore
     compile deps.external.statsdClient
+    compile deps.external.dns
 }
 
 task distJar(type: OneJar) {

--- a/cache/src/dist/config/standalone.yml
+++ b/cache/src/dist/config/standalone.yml
@@ -19,6 +19,7 @@ storeProviderConfig:
     multicastIP: 228.10.10.157
     multicastPort: 6734
     hostIPs:
+    dnsLookupAddress:
     cacheMode: PARTITIONED
     cacheBackupCount: 1
     expirationTimeUnit: DAYS

--- a/cache/src/main/java/com/uber/buckcache/IgniteConfig.java
+++ b/cache/src/main/java/com/uber/buckcache/IgniteConfig.java
@@ -28,6 +28,8 @@ public class IgniteConfig {
   private String offHeapStorageSize;
   @Nonnull
   private List<String> hostIPs;
+  @Nonnull
+  private String dnsLookupAddress;
 
   public List<String> getHostIPs() {
     return hostIPs;
@@ -99,6 +101,14 @@ public class IgniteConfig {
 
   public void setAtomicSequencereserveSize(Integer atomicSequencereserveSize) {
     this.atomicSequencereserveSize = atomicSequencereserveSize;
+  }
+
+  public String getDnsLookupAddress() {
+    return dnsLookupAddress;
+  }
+
+  public void setDnsLookupAddress(String dnsLookupAddress) {
+    this.dnsLookupAddress = dnsLookupAddress;
   }
 
   public String toString() {

--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
@@ -46,7 +46,8 @@ public class IgniteInstance {
   public IgniteInstance(CacheInstanceMode mode, IgniteConfig config) {
     this.config = config;
     this.igniteConfiguration = new IgniteConfigurationBuilder()
-        .addMulticastBasedDiscrovery(this.config.getMulticastIP(), this.config.getMulticastPort(), this.config.getHostIPs())
+        .addMulticastBasedDiscrovery(this.config.getMulticastIP(), this.config.getMulticastPort(),
+            this.config.getHostIPs(), this.config.getDnsLookupAddress())
         .addCacheConfiguration(this.config.getCacheMode(), this.config.getCacheBackupCount(),
             this.config.getExpirationTimeUnit(), this.config.getExpirationTimeValue(),
             this.config.getOffHeapStorageSize(), KEYS_CACHE_NAME, KEYS_REVERSE_CACHE_NAME, METADATA_CACHE_NAME)
@@ -55,7 +56,7 @@ public class IgniteInstance {
     logger.info("isClientMode : {}", mode == CacheInstanceMode.CLIENT);
     Ignition.setClientMode(mode == CacheInstanceMode.CLIENT);
     ignite = Ignition.start(igniteConfiguration);
-    
+
     cacheKeys = ignite.cluster().ignite().getOrCreateCache(KEYS_CACHE_NAME);
     reverseCacheKeys = ignite.cluster().ignite().getOrCreateCache(KEYS_REVERSE_CACHE_NAME);
     buckDataCache = ignite.cluster().ignite().getOrCreateCache(METADATA_CACHE_NAME);

--- a/cache/src/test/java/com/uber/buckcache/datastore/impl/ignite/IgniteConfigurationBuilderTest.java
+++ b/cache/src/test/java/com/uber/buckcache/datastore/impl/ignite/IgniteConfigurationBuilderTest.java
@@ -1,0 +1,55 @@
+package com.uber.buckcache.datastore.impl.ignite;
+
+import com.spotify.dns.DnsSrvResolver;
+import com.spotify.dns.LookupResult;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IgniteConfigurationBuilderTest {
+
+  private static IgniteConfigurationBuilder builder;
+
+  @Test
+  public void testAddMulticastBasedDiscroveryWithoutDNSLookup() throws Exception {
+    IgniteConfiguration configuration = builder.addMulticastBasedDiscrovery(
+        "",
+        0,
+        Arrays.asList("127.0.0.2"),
+        null).build();
+    TcpDiscoverySpi spi = (TcpDiscoverySpi) configuration.getDiscoverySpi();
+    Collection<InetSocketAddress> addrs = spi.getIpFinder().getRegisteredAddresses();
+    Assert.assertEquals(1, addrs.size());
+    Assert.assertEquals("/127.0.0.2:0", addrs.toArray()[0].toString());
+  }
+
+  @Test
+  public void testAddMulticastBasedDiscroveryWithDNSLookup() throws Exception {
+    List<LookupResult> mockAddress = new ArrayList<LookupResult>();
+    mockAddress.add(LookupResult.create("127.0.0.3", 1001, 0, 0, 15));
+    mockAddress.add(LookupResult.create("127.0.0.4", 1001, 0, 0, 15));
+    DnsSrvResolver resolver = mock(DnsSrvResolver.class);
+    when(resolver.resolve("testDNSAddress")).thenReturn(mockAddress);
+    builder = new IgniteConfigurationBuilder(resolver);
+
+    IgniteConfiguration configuration = builder.addMulticastBasedDiscrovery(
+        "",
+        0,
+        new ArrayList<String>(Arrays.asList("127.0.0.2")),
+        "testDNSAddress").build();
+
+    TcpDiscoverySpi spi = (TcpDiscoverySpi) configuration.getDiscoverySpi();
+    Collection<InetSocketAddress> addrs = spi.getIpFinder().getRegisteredAddresses();
+    Assert.assertEquals(3, addrs.size());
+  }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ def versions = [
         jacksonVersion: "2.8.2",
         uuidGenVersion: "3.1.3",
         statsdClientVersion: "3.0.1",
+        dnsVersion: "3.1.4",
 ]
 
 def build = [
@@ -23,6 +24,7 @@ def external = [
         jackson           : "com.fasterxml.jackson.core:jackson-databind:${versions.jacksonVersion}",
         uuidGen           : "com.fasterxml.uuid:java-uuid-generator:${versions.uuidGenVersion}",
         statsdClient      : "com.timgroup:java-statsd-client:${versions.statsdClientVersion}",
+        dns               : "com.spotify:dns:${versions.dnsVersion}",
 ]
 
 ext.deps = [


### PR DESCRIPTION
Currently `buck-http-cache` meed static host IPs (or address) to enable cluster mode, however, this not working well if we have dynamic hosts. For example, when we are using kubernetes to run multiple docker images, we don't know how many hosts we are going to use and the IP / domain name may change.

To solve the problem, the PR is introducing `dnsLookupAddress`, and use `DnsSrvResolver` to lookup all nodes for that particular DNS address.
For example, if we are running the server in kubernetes with port name `buck-http-cache-port` and service name `buck-http-cache`, we can use `_buck-http-cache-port._tcp.buck-http-cache` to lookup DNS. With that, we could save the effort to figure out all host IP / address and don't need zookeeper. 

Sample `standalone.yml`:

```
storeProviderConfig:
  config:
    multicastIP: 228.10.10.157
    multicastPort: 6734
    hostIPs:
    dnsLookupAddress: _buck-http-cache-port._tcp.buck-http-cache
    cacheMode: PARTITIONED
    cacheBackupCount: 1
    expirationTimeUnit: DAYS
    expirationTimeValue: 2
    atomicSequencereserveSize: 10000
    offHeapStorageSize: 40g # 40GB
```

@dhaval2025 @kageiit  could you take a look? Thanks!