### PR TITLE
Fix HttpHeaderAuthFilter crash

### DIFF
--- a/cache/src/main/java/com/uber/buckcache/auth/HttpHeaderAuthFilter.java
+++ b/cache/src/main/java/com/uber/buckcache/auth/HttpHeaderAuthFilter.java
@@ -22,7 +22,7 @@ public class HttpHeaderAuthFilter extends AuthFilter {
   }
 
   public HttpHeaderAuthFilter(List<String> tokens) {
-    this.tokens = tokens;
+    this.tokens = tokens == null ? emptyList() : tokens;
   }
 
   @Override

--- a/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
+++ b/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
@@ -73,10 +73,8 @@ public class BuckCacheResource {
 
   private static String getCacheKeyWithCustomizedParam(String key, String cacheTags) {
     if (StringUtils.isEmpty(cacheTags)) {
-      System.out.println(key);
       return key;
     }
-    System.out.println(String.format("%s.%s", key, cacheTags));
     return String.format("%s.%s", key, cacheTags);
   }
 

--- a/cache/src/test/java/com/uber/buckcache/auth/HttpHeaderAuthFilterTest.java
+++ b/cache/src/test/java/com/uber/buckcache/auth/HttpHeaderAuthFilterTest.java
@@ -31,8 +31,13 @@ public class HttpHeaderAuthFilterTest {
   }
 
   @Test
-  public void testSuccessWithoutAuthenticatedToken() throws IOException {
+  public void testSuccessWithEmptyAuthenticatedToken() throws IOException {
     (new HttpHeaderAuthFilter()).filter(mockRequestContextWithHeader);
+  }
+
+  @Test
+  public void testSuccessWithNullAuthenticatedToken() throws IOException {
+    (new HttpHeaderAuthFilter(null)).filter(mockRequestContextWithHeader);
   }
 
   @Test


### PR DESCRIPTION
When running the newest buck-http-cache server, we encounter error when we trying to call `PUT` endpoint.
After investigate, we found out the problem is here:
https://github.com/uber/buck-http-cache/blob/1f03c97bb8f2fed8ed49d8ff6d9f6d6163acd096/cache/src/main/java/com/uber/buckcache/auth/HttpHeaderAuthFilter.java#L30

#9 change the logic to use `tokens.isEmpty ` to verify if there is any auth token set. However, if we didn't pass anything into `authenticationConfig.tokens`, the code is passing `null` instead of empty when it call `HttpHeaderAuthFilter()`
https://github.com/uber/buck-http-cache/blob/e97e08e7bae8d7bf88e9dbe29b928ee115bf485a/cache/src/main/java/com/uber/buckcache/BuckCacheApplication.java#L77
This case the crash since `tokens` is `null`.

The fix is simply add one more validation when calling `HttpHeaderAuthFilter `, if `tokens == null`, set `this.tokens = emptyList()`. A new test case is added to verify the change.

This PR also remove two debug output which introduced by #13. 

@dhaval2025 @kageiit Please take a look