### PR TITLE
Cluster size metric

### DIFF
--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
@@ -4,6 +4,7 @@ import static com.uber.buckcache.datastore.impl.ignite.IgniteConstants.KEYS_CACH
 import static com.uber.buckcache.datastore.impl.ignite.IgniteConstants.KEYS_REVERSE_CACHE_NAME;
 import static com.uber.buckcache.datastore.impl.ignite.IgniteConstants.METADATA_CACHE_NAME;
 import static com.uber.buckcache.datastore.impl.ignite.IgniteConstants.UNDERLYING_KEY_SEQUENCE_NAME;
+import static com.uber.buckcache.utils.MetricsRegistry.CLUSTER_SIZE;
 import static com.uber.buckcache.utils.MetricsRegistry.CPU_COUNT;
 import static com.uber.buckcache.utils.MetricsRegistry.CPU_TIME;
 import static com.uber.buckcache.utils.MetricsRegistry.HEAP_COUNT;
@@ -142,5 +143,7 @@ public class IgniteInstance {
 
     StatsDClient.get().count(OFF_HEAP_COUNT, offHeapUsage);
     StatsDClient.get().count(OFF_HEAP_TIME, offHeapUsage);
+
+    StatsDClient.get().gauge(CLUSTER_SIZE, ignite.cluster().hostNames().size());
   }
 }

--- a/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
+++ b/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
@@ -4,6 +4,8 @@ public class MetricsRegistry {
   public static final double SAMPLE_RATE = 1;
   
   public static final String SUMMARY_CALL_COUNT = "summary_api_call_count";
+
+  public static final String CLUSTER_SIZE = "buck_cache_cluster_size";
   
   public static final String GET_CALL_COUNT = "get_api_call_count";
   public static final String GET_CALL_TIME = "get_api_call_time_taken";
@@ -28,6 +30,6 @@ public class MetricsRegistry {
   public static final String HEAP_TIME = "buck_cache_server_heap_usage_timer";
   public static final String OFF_HEAP_COUNT = "buck_cache_server_off_heap_usage";
   public static final String OFF_HEAP_TIME = "buck_cache_server_off_heap_usage_timer";
-  
+
   
 }

--- a/cache/src/main/java/com/uber/buckcache/utils/StatsDClient.java
+++ b/cache/src/main/java/com/uber/buckcache/utils/StatsDClient.java
@@ -35,6 +35,10 @@ public class StatsDClient {
     underlyingClient.count(metricName, countValue, statsDConfig.getSampleRate());
   }
 
+  public void gauge(String metricName, long countValue) {
+    underlyingClient.gauge(metricName, countValue);
+  }
+
   public void recordExecutionTime(String metricName, long timeDifferenceInMillis) {
     underlyingClient.recordExecutionTime(metricName, timeDifferenceInMillis, statsDConfig.getSampleRate());
   }


### PR DESCRIPTION
We are using Buck HTTP cache in a cluster mode and it will be great to have a metric per node of how many nodes it sees. We have a suspicion that sometimes a cluster can break into several independent clusters. With that metric we can verify it and add alerts for it.

cc: @zayhero 